### PR TITLE
Added timeout callback example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,22 @@ def click_callback(nid, data):
     print("User clicked on your notification!")
     quit = True
 
+def timeout_callback(nid, data):
+    global quit
+
+    print('Notification timeout!')
+    quit = True
+
 # Create instance of NotificationCenter
 nc = NotificationCenter()
 
-# Create new notification
-nc.create("Test Notification", "Longer notification description. \n With multiline support!", on_click = click_callback)
+# Create new notification, with the defined callbacks
+nc.create(
+    "Test Notification",
+    "Longer notification description. \n With multiline support!",
+    on_click=click_callback
+    on_timeout=timeout_callback
+)
 
 # Update function should be called in your event loop. In this example, we will create our own event loop:
 while nc.update():


### PR DESCRIPTION
Hi, I've just added the timeout example to the existing sample code. I think it is a good idea to have it because when I installed the package the second thing I did was to snooze  the notification to the Notification Centre, and then I was wondering why I clicked on it inside the centre and the callback didn't work. Then I saw that it is a different callback. 😄 